### PR TITLE
Fixes #36

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,11 +230,11 @@ func cordovaVersion() (*ver.Version, error) {
 	if err != nil {
 		return nil, err
 	}
-	version, err := ver.NewVersion(out)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse version: %s", out)
+	lines := strings.Split(out, "\n")
+	if len(lines) > 0 {
+		return lines[len(lines)-1], nil
 	}
-	return version, nil
+	return out, nil
 }
 
 func fail(format string, v ...interface{}) {


### PR DESCRIPTION
Fixes #36
Cordova version output breaks Version library
Uses simple string parsing rather than version parsing