### PR TITLE
Prepare for golangci-lint

### DIFF
--- a/ionic/ionic.go
+++ b/ionic/ionic.go
@@ -51,7 +51,7 @@ func CordovaVersion() (*ver.Version, error) {
 	if err != nil {
 		return nil, err
 	}
-	re := regexp.MustCompile("(?:.*[^0-9])?([0-9]+\\.[0-9]+\\.[0-9]+)(?:[^0-9].*)?")
+	re := regexp.MustCompile(`(?:.*[^0-9])?([0-9]+\.[0-9]+\.[0-9]+)(?:[^0-9].*)?`)
 	matches := re.FindStringSubmatch(out)
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse version: %s", out)

--- a/main.go
+++ b/main.go
@@ -427,9 +427,8 @@ func main() {
 			}
 		}
 		// ---
-	} else {
-		// ios output directory not exists and ios selected as platform
 	}
+	// else: ios output directory not exists and ios selected as platform
 
 	var distPkg []string
 	androidOutputDir := filepath.Join(workDir, "platforms", "android")


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context
We are switching to `golangci-lint` as our go-to linter.

### Changes
**Fixed lint issues found in the repository found by `golangci-lint`.**
