### PR TITLE
chore: migrate sliceutil v1 to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you set the **Build configuration** input in the **Generate Cordova Build Con
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -68,13 +68,13 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Environment Variable | Description |
 | --- | --- |
-| `BITRISE_IPA_PATH` |  |
-| `BITRISE_APP_DIR_PATH` |  |
-| `BITRISE_APP_PATH` |  |
-| `BITRISE_DSYM_DIR_PATH` |  |
-| `BITRISE_DSYM_PATH` |  |
-| `BITRISE_APK_PATH` |  |
-| `BITRISE_APK_PATH_LIST` |  |
+| `BITRISE_IPA_PATH` | The created iOS .ipa file's path. |
+| `BITRISE_APP_DIR_PATH` | The created iOS .app directory's path. |
+| `BITRISE_APP_PATH` | The created iOS .app.zip file's path. |
+| `BITRISE_DSYM_DIR_PATH` | The created iOS .dSYM directory's path. |
+| `BITRISE_DSYM_PATH` | The created iOS .dSYM.zip file's path. |
+| `BITRISE_APK_PATH` | The created Android .apk file's path. |
+| `BITRISE_APK_PATH_LIST` | The created Android .apk file paths, separated by \|. |
 | `BITRISE_AAB_PATH` | This output will include the path of the generated AAB. If the build generates more than one AAB this output will contain the last one's path. |
 | `BITRISE_AAB_PATH_LIST` | This output will include the paths of the generated AABs. The paths are separated with `\|` character, for example, `app--debug.aab\|app-mips-debug.aab` |
 </details>
@@ -83,11 +83,10 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 We welcome [pull requests](https://github.com/bitrise-steplib/steps-ionic-archive/pulls) and [issues](https://github.com/bitrise-steplib/steps-ionic-archive/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 **Note:** this step's end-to-end tests (defined in `e2e/bitrise.yml`) are working with secrets which are intentionally not stored in this repo. External contributors won't be able to run those tests. Don't worry, if you open a PR with your contribution, we will help with running tests and make sure that they pass.
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # Shared test configs
   - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-Ionic-Sample.git
-  - TEST_APP_BRANCH: main
+  - TEST_APP_BRANCH: bb/2026_modernize
   # Shared test secrets
   - BITRISE_APPSTORECONNECT_API_KEY_URL: $BITRISE_APPSTORECONNECT_API_KEY_URL
   - BITRISE_APPSTORECONNECT_API_KEY_ID: $BITRISE_APPSTORECONNECT_API_KEY_ID
@@ -144,15 +144,7 @@ workflows:
         - repository_url: $TEST_APP_URL
         - branch: $TEST_APP_BRANCH
         - clone_into_dir: $BITRISE_SOURCE_DIR/_tmp
-    - script:
-        title: Upgrade cordova-android to v13 for Android SDK XML compatibility
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-            # cordova-android@12 uses AGP 7.x which can't parse the newer Android SDK XML schema.
-            # cordova-android@13 uses AGP 8.x which handles it correctly.
-            sed -i.bak 's/\^12\.[0-9]*\.[0-9]*/^13.0.0/g' $BITRISE_SOURCE_DIR/_tmp/config.xml
+
     - nvm@1:
         inputs:
         - node_version: 18
@@ -160,13 +152,6 @@ workflows:
         run_if: "{{ .IsCI }}"
         inputs:
         - set_java_version: 17
-    - script:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-            # Cordova doesn't install required build-tools package automatically, but requires a minimum version
-            sdkmanager "build-tools;33.0.2"
 
   _install_dependencies_with_npm:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,7 +84,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,OS=latest,name=Bitrise iOS default"
+        -- --buildFlag="-destination platform=iOS Simulator,name=Bitrise iOS default"
     before_run:
     - _setup
     - _install_dependencies_with_npm
@@ -108,7 +108,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,OS=latest,name=Bitrise iOS default"
+        -- --buildFlag="-destination platform=iOS Simulator,name=Bitrise iOS default"
     before_run:
     - _setup
     - _install_dependencies_with_yarn

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,7 +84,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,OS=latest,name=iPhone 11"
+        -- --buildFlag="-destination platform=iOS Simulator,OS=latest,name=Bitrise iOS default"
     before_run:
     - _setup
     - _install_dependencies_with_npm
@@ -108,7 +108,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,OS=latest,name=iPhone 11"
+        -- --buildFlag="-destination platform=iOS Simulator,OS=latest,name=Bitrise iOS default"
     before_run:
     - _setup
     - _install_dependencies_with_yarn

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -150,7 +150,7 @@ workflows:
     - set-java-version:
         run_if: "{{ .IsCI }}"
         inputs:
-        - set_java_version: 11
+        - set_java_version: 17
     - script:
         inputs:
         - content: |-

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -147,7 +147,7 @@ workflows:
 
     - nvm@1:
         inputs:
-        - node_version: 18
+        - node_version: 20
     - set-java-version:
         run_if: "{{ .IsCI }}"
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,7 +84,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,name=Bitrise iOS default"
+        -- --buildFlag="-destination platform=iOS Simulator,name=iPhone SE (3rd generation)"
     before_run:
     - _setup
     - _install_dependencies_with_npm
@@ -108,7 +108,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,name=Bitrise iOS default"
+        -- --buildFlag="-destination platform=iOS Simulator,name=iPhone SE (3rd generation)"
     before_run:
     - _setup
     - _install_dependencies_with_yarn

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -144,6 +144,15 @@ workflows:
         - repository_url: $TEST_APP_URL
         - branch: $TEST_APP_BRANCH
         - clone_into_dir: $BITRISE_SOURCE_DIR/_tmp
+    - script:
+        title: Upgrade cordova-android to v13 for Android SDK XML compatibility
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            # cordova-android@12 uses AGP 7.x which can't parse the newer Android SDK XML schema.
+            # cordova-android@13 uses AGP 8.x which handles it correctly.
+            sed -i.bak 's/\^12\.[0-9]*\.[0-9]*/^13.0.0/g' $BITRISE_SOURCE_DIR/_tmp/config.xml
     - nvm@1:
         inputs:
         - node_version: 18

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,7 +84,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,OS=latest"
+        --
     before_run:
     - _setup
     - _install_dependencies_with_npm
@@ -108,7 +108,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,OS=latest"
+        --
     before_run:
     - _setup
     - _install_dependencies_with_yarn

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,7 +84,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,name=iPhone SE (3rd generation)"
+        -- --buildFlag="-destination platform=iOS Simulator,OS=latest"
     before_run:
     - _setup
     - _install_dependencies_with_npm
@@ -108,7 +108,7 @@ workflows:
     - PLATFORM: ios,android
     - CONFIGURATION: debug
     - OPTIONS: |-
-        -- --buildFlag="-destination platform=iOS Simulator,name=iPhone SE (3rd generation)"
+        -- --buildFlag="-destination platform=iOS Simulator,OS=latest"
     before_run:
     - _setup
     - _install_dependencies_with_yarn

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitrise-steplib/steps-ionic-archive
 
-go 1.18
+go 1.21
 
 require (
 	github.com/bitrise-io/go-steputils v1.0.6

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -16,7 +17,7 @@ import (
 	"github.com/bitrise-io/go-utils/errorutil"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/sliceutil"
+
 	"github.com/bitrise-io/go-utils/ziputil"
 	"github.com/bitrise-steplib/steps-ionic-archive/ionic"
 	ver "github.com/hashicorp/go-version"
@@ -466,11 +467,11 @@ func main() {
 	}
 
 	// if android in platforms
-	if len(distPkg) == 0 && sliceutil.IsStringInSlice("android", platforms) {
+	if len(distPkg) == 0 && slices.Contains(platforms, "android") {
 		fail("No %s generated", ext)
 	}
 	// if ios in platforms
-	if sliceutil.IsStringInSlice("ios", platforms) {
+	if slices.Contains(platforms, "ios") {
 		if len(apps) == 0 && configs.Target == "emulator" {
 			fail("no apps generated")
 		}

--- a/step.yml
+++ b/step.yml
@@ -46,6 +46,7 @@ inputs:
 - platform: ios,android
   opts:
     title: Platform to use in ionic-cli commands
+    summary: Specify this input to apply ionic-cli commands to desired platforms only.
     description: |-
       Specify this input to apply ionic-cli commands to desired platforms only.
 
@@ -58,6 +59,7 @@ inputs:
 - configuration: release
   opts:
     title: Build command configuration
+    summary: Specify build command configuration.
     description: |-
       Specify build command configuration.
 
@@ -69,6 +71,7 @@ inputs:
 - target: device
   opts:
     title: Build command target
+    summary: Specify build command target.
     description: |-
       Specify build command target.
 
@@ -80,11 +83,13 @@ inputs:
 - build_config: $BITRISE_CORDOVA_BUILD_CONFIGURATION
   opts:
     title: Build configuration path, to describe code signing properties
+    summary: Path to the build configuration file (build.json).
     description: |-
       Path to the build configuration file (build.json), which describes code signing properties.
 - options:
   opts:
     title: Options to append to the ionic-cli build command
+    summary: Custom options to append to the ionic-cli build command.
     description: |-
       Use this input to specify custom options, to append to the end of the ionic-cli build command.
 
@@ -98,18 +103,21 @@ inputs:
 - ionic_username:
   opts:
     title: Ionic username
+    summary: Ionic username for ionic-cli login.
     description: |-
       Use `Ionic username` and `Ionic password` to login with ionic-cli.
     is_sensitive: true
 - ionic_password:
   opts:
     title: Ionic password
+    summary: Ionic password for ionic-cli login.
     description: |-
       Use `Ionic username` and `Ionic password` to login with ionic-cli.
     is_sensitive: true
 - ionic_version:
   opts:
     title: Ionic version
+    summary: The version of ionic you want to use.
     description: |-
       The version of ionic you want to use.
 
@@ -118,6 +126,7 @@ inputs:
 - run_ionic_prepare: "true"
   opts:
     title: Should `ionic cordova prepare` be executed before `ionic cordova build`?
+    summary: Should ionic cordova prepare be executed before ionic cordova build.
     description: |-
       It should be set to false if ionic-prepare step is used.
 
@@ -126,6 +135,7 @@ inputs:
 - cordova_version:
   opts:
     title: Cordova version
+    summary: The version of cordova you want to use.
     description: |-
       The version of cordova you want to use.
 
@@ -134,6 +144,7 @@ inputs:
 - workdir: $BITRISE_SOURCE_DIR
   opts:
     title: Working directory
+    summary: Root directory of your Ionic project.
     description: |-
       Root directory of your Ionic project, where your Ionic config.xml exists.
     is_required: true
@@ -153,6 +164,7 @@ inputs:
   opts:
     category: Cache
     title: Cache node_modules
+    summary: Select if the contents of node_modules directory should be cached.
     description: |
       Select if the contents of node_modules directory should be cached.
       `true`: Mark local dependencies to be cached.
@@ -165,24 +177,38 @@ outputs:
 - BITRISE_IPA_PATH:
   opts:
     title: The created ios .ipa file's path
+    summary: The created iOS .ipa file's path.
+    description: The created iOS .ipa file's path.
 - BITRISE_APP_DIR_PATH:
   opts:
     title: The created ios .app dir's path
+    summary: The created iOS .app directory's path.
+    description: The created iOS .app directory's path.
 - BITRISE_APP_PATH:
   opts:
     title: The created ios .app.zip file's path
+    summary: The created iOS .app.zip file's path.
+    description: The created iOS .app.zip file's path.
 - BITRISE_DSYM_DIR_PATH:
   opts:
     title: The created ios .dSYM dir's path
+    summary: The created iOS .dSYM directory's path.
+    description: The created iOS .dSYM directory's path.
 - BITRISE_DSYM_PATH:
   opts:
     title: The created ios .dSYM.zip file's path
+    summary: The created iOS .dSYM.zip file's path.
+    description: The created iOS .dSYM.zip file's path.
 - BITRISE_APK_PATH: ""
   opts:
     title: The created android .apk file's path
+    summary: The created Android .apk file's path.
+    description: The created Android .apk file's path.
 - BITRISE_APK_PATH_LIST: ""
   opts:
     title: The created android .apk file paths (separated via |)
+    summary: The created Android .apk file paths, separated by |.
+    description: The created Android .apk file paths, separated by |.
 - BITRISE_AAB_PATH:
   opts:
     title: Path of the generated AAB


### PR DESCRIPTION
Replace `github.com/bitrise-io/go-utils/sliceutil` (v1) usages:
- `IsStringInSlice` → `slices.Contains` (stdlib)
- `IndexOfStringInSlice` → `slices.Index` (stdlib)